### PR TITLE
feat(염정훈): 리스트 페이지 후원을 기다리는 조공 캐러셀 기능 구현(#30)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,3 @@
 {
+  "cSpell.words": ["swiper"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,12 @@
         "react-router-dom": "^6.24.1",
         "react-scripts": "5.0.1",
         "styled-components": "^6.1.11",
+        "swiper": "^11.1.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.6.0",
+        "@types/swiper": "^6.0.0",
         "customize-cra": "^1.0.0",
         "eslint": "^8.57.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -4562,6 +4564,16 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+    },
+    "node_modules/@types/swiper": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/swiper/-/swiper-6.0.0.tgz",
+      "integrity": "sha512-QPZRgxZ+ivXXtzV43B3LxpXUIC7FE/EoKM+rtxngmgt2M7eeUYypZhyqZD8UxJtlBcUDw/ATGoVeSNpvBBrz2w==",
+      "deprecated": "This is a stub types definition. swiper provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "swiper": "*"
+      }
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",
@@ -16996,6 +17008,24 @@
       "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
       "dependencies": {
         "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.5.tgz",
+      "integrity": "sha512-JJQWFXdxiMGC2j6ZGTYat5Z7NN9JORJBgHp0/joX9uPod+cRj0wr5H5VnWSNIz9JeAamQvYKaG7aFrGHIF9OEg==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-router-dom": "^6.24.1",
     "react-scripts": "5.0.1",
     "styled-components": "^6.1.11",
+    "swiper": "^11.1.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.6.0",
+    "@types/swiper": "^6.0.0",
     "customize-cra": "^1.0.0",
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -8,7 +8,6 @@ import VoteModal from '@components/Modal/VoteModal';
 import MyCredit from './components/MyCredit';
 import TributeSupport from './components/TributeSupport';
 import MonthChart from './components/MonthChart';
-// import DonationModal from '@components/Modal/DonationModal';
 
 function ListPageContent() {
   // Context

--- a/src/pages/ListPage/components/IdolCard.jsx
+++ b/src/pages/ListPage/components/IdolCard.jsx
@@ -54,12 +54,7 @@ const IdolCardWrap = styled.div`
   width: 100%;
   max-width: 280px;
 
-  @media screen and (max-width: 744px) {
-    min-width: 280px;
-  }
-
   @media screen and (max-width: 375px) {
-    min-width: 160px;
     max-width: 160px;
   }
 `;
@@ -70,6 +65,7 @@ const IdolCardImage = styled.div`
   max-height: 290px;
   overflow: hidden;
   margin-bottom: 10px;
+  border-radius: 8px;
 
   &::after {
     position: absolute;
@@ -101,8 +97,13 @@ const IdolCardImage = styled.div`
     max-width: 235px;
     z-index: 2;
 
+    @media screen and (max-width: 3744px) {
+      bottom: 20px;
+    }
+
     @media screen and (max-width: 375px) {
       height: 30px;
+      bottom: 10px;
     }
   }
 `;

--- a/src/pages/ListPage/components/IdolCard.jsx
+++ b/src/pages/ListPage/components/IdolCard.jsx
@@ -97,7 +97,7 @@ const IdolCardImage = styled.div`
     max-width: 235px;
     z-index: 2;
 
-    @media screen and (max-width: 3744px) {
+    @media screen and (max-width: 744px) {
       bottom: 20px;
     }
 

--- a/src/pages/ListPage/components/TributeSupport.jsx
+++ b/src/pages/ListPage/components/TributeSupport.jsx
@@ -22,7 +22,7 @@ export default function TributeSupport() {
       spaceBetween: 16,
     },
     0: {
-      // 0 이상 적용(mo버전)
+      // 0 이상 적용(moblie버전)
       slidesPerView: 2.1,
       spaceBetween: 8,
     },

--- a/src/pages/ListPage/components/TributeSupport.jsx
+++ b/src/pages/ListPage/components/TributeSupport.jsx
@@ -10,7 +10,7 @@ import 'swiper/css/navigation';
 
 export default function TributeSupport() {
   // swiper 반응형 지정
-  const swiperBreakpoints = {
+  const SWIPERBREAKPOINTS = {
     745: {
       // 745 이상 적용(pc버전)
       slidesPerView: 4,
@@ -29,13 +29,13 @@ export default function TributeSupport() {
   };
 
   // swiper 화살표 버튼 지정
-  const swiperNavigation = {
+  const SWIPERNAVIGATION = {
     nextEl: '.swiper-button-next',
     prevEl: '.swiper-button-prev',
   };
 
   // swiper 자동 재생
-  const swiperAutoplay = {
+  const SWIPERAUTOPLAY = {
     delay: 4000, // 4초마다 자동 재생
     disableOnInteraction: false, // 사용자가 슬라이더를 변경해도 자동재생 유지
   };
@@ -50,10 +50,10 @@ export default function TributeSupport() {
           <img src={LeftArrow} alt="왼쪽 화살표 이미지" />
         </ArrowButton>
         <Swiper
-          breakpoints={swiperBreakpoints}
-          autoplay={swiperAutoplay}
+          breakpoints={SWIPERBREAKPOINTS}
+          autoplay={SWIPERAUTOPLAY}
           modules={[Navigation, Autoplay]}
-          navigation={swiperNavigation}
+          navigation={SWIPERNAVIGATION}
         >
           <SwiperSlide>
             <IdolCard />

--- a/src/pages/ListPage/components/TributeSupport.jsx
+++ b/src/pages/ListPage/components/TributeSupport.jsx
@@ -10,7 +10,7 @@ import 'swiper/css/navigation';
 
 export default function TributeSupport() {
   // swiper 반응형 지정
-  const SWIPERBREAKPOINTS = {
+  const SWIPER_BREAKPOINTS = {
     745: {
       // 745 이상 적용(pc버전)
       slidesPerView: 4,
@@ -29,13 +29,13 @@ export default function TributeSupport() {
   };
 
   // swiper 화살표 버튼 지정
-  const SWIPERNAVIGATION = {
+  const SWIPER_NAVIGATION = {
     nextEl: '.swiper-button-next',
     prevEl: '.swiper-button-prev',
   };
 
   // swiper 자동 재생
-  const SWIPERAUTOPLAY = {
+  const SWIPER_AUTOPLAY = {
     delay: 4000, // 4초마다 자동 재생
     disableOnInteraction: false, // 사용자가 슬라이더를 변경해도 자동재생 유지
   };
@@ -50,10 +50,10 @@ export default function TributeSupport() {
           <img src={LeftArrow} alt="왼쪽 화살표 이미지" />
         </ArrowButton>
         <Swiper
-          breakpoints={SWIPERBREAKPOINTS}
-          autoplay={SWIPERAUTOPLAY}
+          breakpoints={SWIPER_BREAKPOINTS}
+          autoplay={SWIPER_AUTOPLAY}
           modules={[Navigation, Autoplay]}
-          navigation={SWIPERNAVIGATION}
+          navigation={SWIPER_NAVIGATION}
         >
           <SwiperSlide>
             <IdolCard />

--- a/src/pages/ListPage/components/TributeSupport.jsx
+++ b/src/pages/ListPage/components/TributeSupport.jsx
@@ -1,28 +1,88 @@
 import React from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Autoplay } from 'swiper/modules';
 import styled from 'styled-components';
 import LeftArrow from '@assets/svg/btn_pagination_arrow_left.svg';
 import RightArrow from '@assets/svg/btn_pagination_arrow_right.svg';
 import IdolCard from './IdolCard';
+import 'swiper/css';
+import 'swiper/css/navigation';
 
 export default function TributeSupport() {
+  // swiper 반응형 지정
+  const swiperBreakpoints = {
+    745: {
+      // 745 이상 적용(pc버전)
+      slidesPerView: 4,
+      spaceBetween: 24,
+    },
+    376: {
+      // 376 이상 적용(tablet버전)
+      slidesPerView: 2.4,
+      spaceBetween: 16,
+    },
+    0: {
+      // 0 이상 적용(mo버전)
+      slidesPerView: 2.1,
+      spaceBetween: 8,
+    },
+  };
+
+  // swiper 화살표 버튼 지정
+  const swiperNavigation = {
+    nextEl: '.swiper-button-next',
+    prevEl: '.swiper-button-prev',
+  };
+
+  // swiper 자동 재생
+  const swiperAutoplay = {
+    delay: 4000, // 4초마다 자동 재생
+    disableOnInteraction: false, // 사용자가 슬라이더를 변경해도 자동재생 유지
+  };
+
   return (
     <MyCreditWrap>
       <ListPageSubTitle>
         <h2>후원을 기다리는 조공</h2>
       </ListPageSubTitle>
       <IdolTributeList>
-        <button type="button">
+        <ArrowButton className="swiper-button-prev" type="button">
           <img src={LeftArrow} alt="왼쪽 화살표 이미지" />
-        </button>
-        <IdolCardBox>
-          <IdolCard />
-          <IdolCard />
-          <IdolCard />
-          <IdolCard />
-        </IdolCardBox>
-        <button type="button">
+        </ArrowButton>
+        <Swiper
+          breakpoints={swiperBreakpoints}
+          autoplay={swiperAutoplay}
+          modules={[Navigation, Autoplay]}
+          navigation={swiperNavigation}
+        >
+          <SwiperSlide>
+            <IdolCard />
+          </SwiperSlide>
+          <SwiperSlide>
+            <IdolCard />
+          </SwiperSlide>
+          <SwiperSlide>
+            <IdolCard />
+          </SwiperSlide>
+          <SwiperSlide>
+            <IdolCard />
+          </SwiperSlide>
+          <SwiperSlide>
+            <IdolCard />
+          </SwiperSlide>
+          <SwiperSlide>
+            <IdolCard />
+          </SwiperSlide>
+          <SwiperSlide>
+            <IdolCard />
+          </SwiperSlide>
+          <SwiperSlide>
+            <IdolCard />
+          </SwiperSlide>
+        </Swiper>
+        <ArrowButton className="swiper-button-next" type="button">
           <img src={RightArrow} alt="오른쪽 화살표 이미지" />
-        </button>
+        </ArrowButton>
       </IdolTributeList>
     </MyCreditWrap>
   );
@@ -70,22 +130,31 @@ const ListPageSubTitle = styled.div`
 `;
 
 const IdolTributeList = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
   gap: 40px;
   width: 100%;
-  max-width: 1360px;
+  max-width: 1340px;
   margin: 0 auto;
 
-  @media screen and (max-width: 744px) {
-    overflow-x: scroll;
-    padding-bottom: 10px;
+  & > .swiper {
+    max-width: 1200px;
+  }
+`;
+
+const ArrowButton = styled.button`
+  opacity: 0.7;
+  &.swiper-button-disabled {
+    display: none;
   }
 
-  & > button {
-    @media screen and (max-width: 744px) {
-      display: none;
-    }
+  @media screen and (max-width: 744px) {
+    display: none;
+  }
+
+  &::after {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
### 변경사항

- 리스트 페이지 후원을 기다리는 조공 캐러셀 기능 추가
- 캐러셀 기능 반응형 동작 추가

### 셀프 체크 리스트

- [x] 코드 컨벤션 준수
- [x] 테스트 여부

### 스크린샷
- pc버전(처음 슬라이드에는 왼쪽 화살표 없음)
![image](https://github.com/user-attachments/assets/9002c76c-d158-464e-af59-9c98445dfe20)

- pc버전(화살표 양쪽 다 있음)
![image](https://github.com/user-attachments/assets/57d3eab0-5b76-4c84-803d-ccab621c770f)

- pc버전(마지막 슬라이드에는 오른쪽 화살표 없음)
![image](https://github.com/user-attachments/assets/2c181fff-1953-426b-a62e-b6eb838d4281)

- table버전
![image](https://github.com/user-attachments/assets/c2622b15-55c1-462f-9118-bfe704237cf4)

- mo버전
![image](https://github.com/user-attachments/assets/282df879-efaa-4ae0-9199-961895b90758)


### 추가 공유 사항
- swiper 라이브러리를 추가했습니다.
- 4초마다 후원 리스트라 자동으로 슬라이드 되도록 하는 기능을 추가했습니다.
