### PR TITLE
feat(염정훈): 리스트 페이지 내 크레딧 로컬 스토리지 구현(#37)

### DIFF
--- a/src/components/CircularIdolImage.jsx
+++ b/src/components/CircularIdolImage.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import IdolImg from '@assets/TestIdolImage/Winter.png';
+import IdolImage from '@assets/TestIdolImage/Winter.png';
 import { ReactComponent as CheckIcon } from '@assets/svg/ic_check.svg';
 import { ReactComponent as DeleteButton } from '@assets/svg/btn_delete.svg';
 
@@ -23,7 +23,7 @@ export default function CircularIdolImage({
   size = 'small',
   onDelete = null,
   onCheckChange = null,
-  idolImage = IdolImg,
+  idolImage = IdolImage,
 }) {
   const handleImageClick = () => {
     if (isCheckable && onCheckChange) {
@@ -60,6 +60,7 @@ CircularIdolImage.propTypes = {
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   onDelete: PropTypes.func,
   onCheckChange: PropTypes.func,
+  idolImage: PropTypes.string.isRequired,
 };
 
 // styled-components

--- a/src/pages/ListPage/components/MyCredit.jsx
+++ b/src/pages/ListPage/components/MyCredit.jsx
@@ -1,12 +1,20 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useModalContext } from '@contexts/useModalContext';
 import CreditImage from '@assets/svg/ic_credit.svg';
 
 export default function MyCredit({ openModal }) {
   // State
-  const [myCredit, setMyCredit] = useState(3600);
+  const [myCredit, setMyCredit] = useState(() => {
+    const initialCredit = localStorage.getItem('myCredit');
+    return initialCredit ? Number(initialCredit) : 0;
+  });
+
+  // 크레딧이 변경 되면 localStorage에 있는 크레딧 수정
+  useEffect(() => {
+    localStorage.setItem('myCredit', myCredit);
+  }, [myCredit]);
 
   return (
     <MyCreditWrap>


### PR DESCRIPTION
### 변경사항

- 내 크레딧 로컬 스토리지 구현
- CircularIdolImage.jsx 컴포넌트 img 축약어 수정

### 셀프 체크 리스트

- [x] 코드 컨벤션 준수
- [x] 테스트 여부

