### PR TITLE
feat(장혁수): 랜딩페이지 localstorage 초기화하는 버튼 추가(#49)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14872,13 +14872,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-type": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/prop-type/-/prop-type-0.0.1.tgz",
-      "integrity": "sha512-6+7BTexA1dif2J3zyeVZB5sn3KVb/7iRJKruWTHpeHD99rUmWTHp7Vp51rPGPIa9av4HX1g+2D2gdIAWOhI7gw==",
-      "deprecated": "this package is no longer maintained and propably broken",
-      "license": "MIT"
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",

--- a/src/pages/LandingPage/LandingPage.jsx
+++ b/src/pages/LandingPage/LandingPage.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import logo from '@assets/svg/logo.svg';
 import backgroundImage from '@assets/LandingPage/image 14.png';
 import topDesign from '@assets/svg/Image_top.svg';
@@ -12,6 +12,13 @@ import landingImage3 from '@assets/LandingPage/Home-3.png';
 import Button from '@components/Button';
 
 export default function LandingPage() {
+  const navigate = useNavigate();
+
+  const handleStartClick = () => {
+    localStorage.clear();
+    navigate('/list');
+  };
+
   return (
     <div>
       <Main>
@@ -27,7 +34,7 @@ export default function LandingPage() {
         </LogoWrap>
         <BackgroundImage src={backgroundImage} alt="배경 이미지" />
         <ButtonWrap>
-          <Button>지금 시작하기</Button>
+          <Button onClick={handleStartClick}>지금 시작하기</Button>
         </ButtonWrap>
       </Main>
       <BottomContainer>

--- a/src/pages/MyPage/Components/MiniPhotoCard.jsx
+++ b/src/pages/MyPage/Components/MiniPhotoCard.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import CircularIdolImage from '@components/CircularIdolImage';
-import PropTypes from 'prop-type';
+import PropTypes from 'prop-types';
 
 export default function MiniPhotoCard({
   isCheckable = true,


### PR DESCRIPTION
### 변경사항

- 랜딩 페이지에서 "지금 시작하기" 버튼 클릭 시 localStorage가 초기화되고, "/list"페이지로 이동하는 기능을 추가

### 셀프 체크 리스트

- [x] 코드 컨벤션 준수
- [x] 테스트 여부

### 스크린샷
크레딧 충전하기 전
![스크린샷(50)](https://github.com/user-attachments/assets/b0f745ed-76db-4c8c-8d28-7145959c3d99)

크레딧 충전 후
![스크린샷(49)](https://github.com/user-attachments/assets/06ce648f-ee43-4e5f-8e11-ce7b1a3e937d)
 
렌딩 페이지 이동
![스크린샷(48)](https://github.com/user-attachments/assets/506331a8-c62b-40ba-a0b6-005174b91e35)

"지금 시작하기" 버튼 클릭 후 localStorage 초기화
![스크린샷(50)](https://github.com/user-attachments/assets/b0f745ed-76db-4c8c-8d28-7145959c3d99)



### 추가 공유 사항
