### PR TITLE
feat(임귀태): Toast 및 VoteModal UI 구현  (#47)

### DIFF
--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -57,7 +57,7 @@ export default function LoadingSpinner({
 }
 
 LoadingSpinner.propTypes = {
-  size: PropTypes.number.isRequired,
-  color: PropTypes.string.isRequired,
-  minLoadTime: PropTypes.number.isRequired,
+  size: PropTypes.number,
+  color: PropTypes.string,
+  minLoadTime: PropTypes.number,
 };

--- a/src/components/Modal/ChargeModal.jsx
+++ b/src/components/Modal/ChargeModal.jsx
@@ -30,7 +30,7 @@ export default function ChargeModal({ isOpen, onClose }) {
   };
 
   return (
-    <Modal isOpen={isOpen}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <StyledChargeModalWindow>
         <ModalTopBar onClose={onClose}>크레딧 충전하기</ModalTopBar>
         <StyledContainer>

--- a/src/components/Modal/ChargeModal.jsx
+++ b/src/components/Modal/ChargeModal.jsx
@@ -5,8 +5,10 @@ import {
   BasedContainer,
   StyledCreditIcon,
   StyledCreditIconWhite,
+  StyledDivider,
 } from '@styles/CommonStyles';
 import { useCreditContext } from '@contexts/useCreditContext';
+import { useToastContext } from '@contexts/useToastContext';
 import Modal, { ModalWindow } from '@components/Modal/Modal';
 import ModalTopBar from '@components/Modal/ModalTopbar';
 import RadioButton from '@components/RadioButton';
@@ -24,6 +26,7 @@ export default function ChargeModal({ isOpen, onClose }) {
 
   // Context
   const { myCredit, setMyCredit } = useCreditContext();
+  const { addToast } = useToastContext();
 
   const handleOption = (e) => {
     setOptionValue(e.target.value);
@@ -53,6 +56,7 @@ export default function ChargeModal({ isOpen, onClose }) {
           </StyledButtonWrapper>
           <ChargeButton
             onClose={onClose}
+            addToast={addToast}
             optionValue={optionValue}
             myCredit={myCredit}
             setMyCredit={setMyCredit}
@@ -149,9 +153,20 @@ CreditOptionButton.propTypes = {
   onClick: PropTypes.func,
 };
 
-const ChargeButton = ({ onClose, optionValue, myCredit, setMyCredit }) => {
+const ChargeButton = ({
+  onClose,
+  addToast,
+  optionValue,
+  myCredit,
+  setMyCredit,
+}) => {
   const submitOption = () => {
     setMyCredit(Number(myCredit) + Number(optionValue));
+    addToast(
+      <span>
+        <em>{Number(optionValue)}</em> 만큼의 크레딧 충전을 완료했습니다.
+      </span>
+    );
     onClose();
   };
 
@@ -165,6 +180,7 @@ const ChargeButton = ({ onClose, optionValue, myCredit, setMyCredit }) => {
 
 ChargeButton.propTypes = {
   onClose: PropTypes.func.isRequired,
+  addToast: PropTypes.func.isRequired,
   optionValue: PropTypes.string.isRequired,
   myCredit: PropTypes.number.isRequired,
   setMyCredit: PropTypes.func.isRequired,

--- a/src/components/Modal/DonationModal.jsx
+++ b/src/components/Modal/DonationModal.jsx
@@ -238,7 +238,7 @@ const CreditIcon = styled(StyledCreditIcon)`
 
 const ErrorSpan = styled.span`
   position: absolute;
-  top: 68px;
+  top: 67px;
 
   color: var(--error-red);
   font-size: 12px;

--- a/src/components/Modal/DonationModal.jsx
+++ b/src/components/Modal/DonationModal.jsx
@@ -3,9 +3,14 @@ import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 import { useModalContext } from '@contexts/useModalContext';
 import { useCreditContext } from '@contexts/useCreditContext';
+import { useToastContext } from '@contexts/useToastContext';
 import Modal, { ModalWindow } from '@components/Modal/Modal';
 import ModalTopBar from '@components/Modal/ModalTopbar';
-import { BasedContainer, StyledCreditIcon } from '@styles/CommonStyles';
+import {
+  BasedContainer,
+  StyledCreditIcon,
+  StyledDivider,
+} from '@styles/CommonStyles';
 import Button from '@components/Button';
 // assets
 import AltImage from '@assets/png/alt_image.png';
@@ -27,6 +32,7 @@ export default function DonationModal({ isOpen, onClose }) {
   const { modals, openModal } = useModalContext();
   const idolData = modals.DonationModal?.data;
   const { myCredit, setMyCredit } = useCreditContext();
+  const { addToast } = useToastContext();
 
   // inputValue의 값이 크레딧보다 높으면 Error
   useEffect(() => {
@@ -55,13 +61,17 @@ export default function DonationModal({ isOpen, onClose }) {
       });
     }
     if (submitAmount <= myCredit) {
-      /** @todo2 후원 성공에 대한 팝업 구현 */
       try {
         putDonationsContribute({
           donationId: idolData.donationId,
           donationAmount: submitAmount,
         });
         setMyCredit(myCredit - submitAmount);
+        addToast(
+          <span>
+            <em>후원</em>을 완료했습니다!
+          </span>
+        );
       } catch (error) {
         console.error('Failed to submit donation:', error);
       } finally {

--- a/src/components/Modal/DonationModal.jsx
+++ b/src/components/Modal/DonationModal.jsx
@@ -92,7 +92,7 @@ export default function DonationModal({ isOpen, onClose }) {
   };
 
   return (
-    <Modal isOpen={isOpen}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <StyledDonationModalWindow>
         <ModalTopBar onClose={onClose}>후원하기</ModalTopBar>
         <StyledContainer>

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -4,16 +4,28 @@ import styled, { keyframes } from 'styled-components';
 /** 공용 모달 컴포넌트
  * @param {Object} props - 컴포넌트 props
  * @param {boolean} props.isOpen - 모달이 열려 있는지 여부
+ * @param {function} props.onClose - 모달을 닫기 위한 함수
  * @return {JSX.Element} 공용 모달 컴포넌트
  */
-export default function Modal({ isOpen, children }) {
+export default function Modal({ isOpen, onClose, children }) {
   if (!isOpen) return null;
 
-  return <ModalBackground>{children}</ModalBackground>;
+  const handleBackgroundClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <ModalBackground onClick={handleBackgroundClick}>
+      {children}
+    </ModalBackground>
+  );
 }
 
 Modal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
   children: PropTypes.node.isRequired,
 };
 

--- a/src/components/Modal/ModalTopbar.jsx
+++ b/src/components/Modal/ModalTopbar.jsx
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { StyledDeleteButton } from '@styles/CommonStyles';
+import {
+  StyledDeleteButton,
+  StyledArrowLeftButton,
+} from '@styles/CommonStyles';
 
 /** 모달 상단의 제목/창 닫기 탑바
  * @param {Object} props - 컴포넌트 props
- * @param props.onClose {function} - Modal을 닫는 함수
- * @param props.children - Modal 제목
+ * @param {function} props.onClose - Modal을 닫는 함수
+ * @param {React.ReactNode} props.children - Modal 제목
  */
 export default function ModalTopBar({ children, onClose }) {
   return (
@@ -38,4 +41,53 @@ const StyledModalTopBar = styled.div`
     font-weight: 600;
     line-height: normal;
   }
+`;
+
+/** -------------------------------------------------- */
+
+/** 모달 상단의 제목/창 닫기 탑바
+ * @param {Object} props - 컴포넌트 props
+ * @param {function} props.onClose - Modal을 닫는 함수
+ * @param {React.ReactNode} props.children - Modal 제목
+ */
+export function MobileTopBar({ children, onClose }) {
+  return (
+    <StyledMobileModalTopBar>
+      <StyledStyledArrowLeftButton onClick={onClose} />
+      <span>{children}</span>
+    </StyledMobileModalTopBar>
+  );
+}
+
+MobileTopBar.propTypes = {
+  children: PropTypes.node,
+  onClose: PropTypes.func.isRequired,
+};
+
+// styled-components
+
+const StyledMobileModalTopBar = styled.div`
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 56px;
+  padding: 8px 24px;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+
+  span {
+    color: var(--white, #f7f7f8);
+    font-family: Pretendard;
+    font-size: 18px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+  }
+`;
+
+const StyledStyledArrowLeftButton = styled(StyledArrowLeftButton)`
+  position: fixed;
+  left: 24px;
+  z-index: 100;
 `;

--- a/src/components/Modal/PopupModal.jsx
+++ b/src/components/Modal/PopupModal.jsx
@@ -19,7 +19,7 @@ export default function PopupModal({ isOpen = false, onClose }) {
   const { modals } = useModalContext();
 
   return (
-    <Modal isOpen={isOpen}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <StyledPopupWindow>
         <ModalTopBar onClose={onClose} />
         <StyledContainer>

--- a/src/components/Modal/Toast.jsx
+++ b/src/components/Modal/Toast.jsx
@@ -49,7 +49,7 @@ const ToastAnimation = keyframes`
     transform: translateY(0);
   }
   30%, 70% {
-    transform: translateY(-110px);
+    transform: translateY(-108px);
   }
   100% {
     transform: translateY(0);

--- a/src/components/Modal/Toast.jsx
+++ b/src/components/Modal/Toast.jsx
@@ -1,0 +1,99 @@
+import { useEffect } from 'react';
+import styled, { keyframes } from 'styled-components';
+import PropTypes from 'prop-types';
+import { useModalContext } from '@contexts/useModalContext';
+import {
+  BasedContainer,
+  StyledCreditIcon,
+  StyledDivider,
+} from '@styles/CommonStyles';
+
+/** 팝업 모달 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {boolean} props.isOpen - Toast가 열려 있는지 여부
+ * @param {function} props.onClose - Toast를 닫기 위한 함수
+ * @param {string} props.message - Toast에 표시할 메시지
+ * @return {JSX.Element} Toast 컴포넌트
+ */
+export default function Toast({ isOpen = true, onClose, message }) {
+  if (!isOpen) return null;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onClose();
+    }, 6000); // 6초 후 모달 닫기
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  return (
+    <AlignDiv>
+      <StyledToastWindow>
+        <StyledContainer>
+          <StyledCreditIcon />
+          <StyledDivider />
+          {message}
+        </StyledContainer>
+      </StyledToastWindow>
+    </AlignDiv>
+  );
+}
+
+Toast.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  message: PropTypes.node.isRequired,
+};
+
+const ToastAnimation = keyframes`
+  0% { 
+    transform: translateY(0);
+  }
+  30%, 70% {
+    transform: translateY(-110px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+`;
+
+const AlignDiv = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  pointer-events: none;
+`;
+
+const StyledToastWindow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: column;
+  position: fixed;
+  bottom: -100px;
+  width: auto;
+  height: auto;
+  padding: 12px 24px;
+  border: 1px solid var(--brand-coral);
+  border-radius: 12px;
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  background-color: var(--light-black);
+  animation: ${ToastAnimation} 6s ease-in-out;
+  gap: 4px;
+  z-index: 1000;
+  pointer-events: none;
+`;
+
+const StyledContainer = styled(BasedContainer)`
+  display: flex;
+  gap: 4px;
+  width: auto;
+  min-width: 100px;
+  pointer-events: none;
+
+  span {
+    font-size: 16px;
+    font-style: normal;
+    color: var(--white);
+    line-height: 26px;
+  }
+`;

--- a/src/components/Modal/VoteModal.jsx
+++ b/src/components/Modal/VoteModal.jsx
@@ -300,7 +300,6 @@ const VoteOption = ({ onClick, selectedIdol, idolData, hasVoted }) => {
 
 VoteOption.propTypes = {
   onClick: PropTypes.func.isRequired,
-  /** @todo 추후에 State로 Key 변경할 경우 selectedIdol PropTypes 변동 가능성 있음 */
   selectedIdol: PropTypes.number.isRequired,
   idolData: PropTypes.shape({
     profilePicture: PropTypes.string.isRequired,

--- a/src/components/Modal/VoteModal.jsx
+++ b/src/components/Modal/VoteModal.jsx
@@ -92,7 +92,7 @@ export default function VoteModal({ isOpen = false, onClose }) {
   }, [responsiveStatus]);
 
   return (
-    <Modal isOpen={isOpen}>
+    <Modal isOpen={isOpen} onClose={onClose}>
       <StyledVoteModalWindow>
         {responsiveStatus === RESPONSIVE_VALUE.PC ? (
           <ModalTopBar onClose={onClose}>이달의 여자 아이돌</ModalTopBar>
@@ -206,10 +206,10 @@ const StyledVoteOptionList = styled(BasedContainer)`
     border-radius: 3px;
     background: linear-gradient(
       60deg,
-      rgba(249, 110, 104, 0.5),
-      #f96e68 20%,
-      #fe578f 80%,
-      rgba(254, 87, 143, 0.5)
+      rgba(249, 110, 104, 0.8),
+      var(--brand-coral) 20%,
+      var(--brand-pink) 80%,
+      rgba(254, 87, 143, 0.8)
     );
   }
 
@@ -238,7 +238,7 @@ const StyledVoteOption = styled.div`
     display: flex;
     width: 100%;
     background: var(--dark-black);
-    padding-right: 12px;
+    padding-right: 16px;
   }
 `;
 

--- a/src/components/Modal/VoteModal.jsx
+++ b/src/components/Modal/VoteModal.jsx
@@ -118,6 +118,7 @@ export default function VoteModal({ isOpen = false, onClose }) {
                 }
                 selectedIdol={selectedIdol}
                 idolData={idolData}
+                hasVoted={localStorage.getItem('hasVoted')}
               />
               <StyledDivider />
             </>
@@ -185,7 +186,6 @@ const StyledVoteOptionList = styled(BasedContainer)`
   justify-content: flex-start;
   align-items: flex-start;
   gap: 8px;
-  cursor: pointer;
   overflow-y: auto;
   flex-grow: 1;
   padding-top: 8px;
@@ -229,6 +229,7 @@ const StyledVoteOption = styled.div`
   justify-content: space-between;
   align-items: center;
   flex-shrink: 0;
+  cursor: ${(props) => (props.hasVoted === 'true' ? 'default' : 'pointer')};
 
   @media screen and (max-width: 480px) {
     display: flex;
@@ -276,9 +277,9 @@ const StyledVotes = styled.span`
   line-height: normal;
 `;
 
-const VoteOption = ({ onClick, selectedIdol, idolData }) => {
+const VoteOption = ({ onClick, selectedIdol, idolData, hasVoted }) => {
   return (
-    <StyledVoteOption onClick={() => onClick(idolData?.id)}>
+    <StyledVoteOption onClick={() => onClick(idolData?.id)} hasVoted={hasVoted}>
       <StyledIdolInfo>
         <CircularIdolImage
           idolImage={idolData?.profilePicture}
@@ -309,6 +310,7 @@ VoteOption.propTypes = {
     name: PropTypes.string.isRequired,
     totalVotes: PropTypes.number.isRequired,
   }).isRequired,
+  hasVoted: PropTypes.string.isRequired,
 };
 
 const StyledDiv = styled.div`

--- a/src/components/Modal/VoteModal.jsx
+++ b/src/components/Modal/VoteModal.jsx
@@ -190,9 +190,28 @@ const StyledVoteOptionList = styled(BasedContainer)`
   align-items: flex-start;
   gap: 8px;
   cursor: pointer;
-  overflow-y: scroll;
+  overflow-y: auto;
   flex-grow: 1;
   padding-top: 8px;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background: linear-gradient(60deg, #f96e68, #fe578f);
+    /* background: linear-gradient(60deg, black -9.84%, white 107.18%); */
+  }
+
+  &::-webkit-scrollbar-button {
+    width: 0;
+    height: 0;
+  }
 
   @media screen and (max-width: 480px) {
     width: 100%;

--- a/src/components/Modal/VoteModal.jsx
+++ b/src/components/Modal/VoteModal.jsx
@@ -203,9 +203,14 @@ const StyledVoteOptionList = styled(BasedContainer)`
   }
 
   &::-webkit-scrollbar-thumb {
-    border-radius: 2px;
-    background: linear-gradient(60deg, #f96e68, #fe578f);
-    /* background: linear-gradient(60deg, black -9.84%, white 107.18%); */
+    border-radius: 3px;
+    background: linear-gradient(
+      60deg,
+      rgba(249, 110, 104, 0.5),
+      #f96e68 20%,
+      #fe578f 80%,
+      rgba(254, 87, 143, 0.5)
+    );
   }
 
   &::-webkit-scrollbar-button {

--- a/src/contexts/useToastContext.js
+++ b/src/contexts/useToastContext.js
@@ -1,0 +1,53 @@
+import {
+  createContext,
+  useState,
+  useCallback,
+  useContext,
+  useMemo,
+} from 'react';
+import PropTypes from 'prop-types';
+
+const ToastContext = createContext();
+
+/**
+ * Toast를 Context로 설정하는 Provider
+ *
+ * @param children - 태그 내부 (자식 컴포넌트들)
+ */
+export const ToastProvider = ({ children }) => {
+  const [toasts, setToasts] = useState([]);
+
+  const addToast = useCallback((message) => {
+    const id = Date.now();
+    setToasts((prevToasts) => [...prevToasts, { id, message }]);
+  }, []);
+
+  const closeToast = useCallback((id) => {
+    setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ toasts, addToast, closeToast }),
+    [toasts]
+  );
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+    </ToastContext.Provider>
+  );
+};
+
+ToastProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+/**
+ * Toast 컨텍스트를 사용하기 위한 Custom Hook
+ *
+ * @returns
+ * - {Array} toasts - 현재 표시되고 있는 토스트 배열
+ * - {Function} addToast - 새 토스트를 띄우는 함수
+ * - {Function} closeToast - 토스트를 제거하는 함수
+ */
+export const useToastContext = () => useContext(ToastContext);

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -1,10 +1,12 @@
 import { ModalProvider, useModalContext } from '@contexts/useModalContext';
 import { CreditProvider } from '@contexts/useCreditContext';
+import { ToastProvider, useToastContext } from '@contexts/useToastContext';
 // Modals
 import ChargeModal from '@components/Modal/ChargeModal';
 import PopupModal from '@components/Modal/PopupModal';
 import DonationModal from '@components/Modal/DonationModal';
 import VoteModal from '@components/Modal/VoteModal';
+import Toast from '@components/Modal/Toast';
 // Components
 import Header from '@components/Header';
 import MyCredit from './components/MyCredit';
@@ -14,6 +16,7 @@ import MonthChart from './components/MonthChart';
 function ListPageContent() {
   // Context
   const { modals, openModal, closeModal } = useModalContext();
+  const { toasts, addToast, closeToast } = useToastContext();
 
   return (
     <>
@@ -41,6 +44,14 @@ function ListPageContent() {
           onClose={() => closeModal('PopupModal')}
         />
       )}
+      {toasts.map((toast) => (
+        <Toast
+          key={toast.id}
+          isOpen
+          onClose={() => closeToast(toast.id)}
+          message={toast.message}
+        />
+      ))}
       <Header />
       <MyCredit openModal={openModal} />
       <TributeSupport />
@@ -53,7 +64,9 @@ export default function ListPage() {
   return (
     <CreditProvider>
       <ModalProvider>
-        <ListPageContent />
+        <ToastProvider>
+          <ListPageContent />
+        </ToastProvider>
       </ModalProvider>
     </CreditProvider>
   );

--- a/src/styles/CommonStyles.js
+++ b/src/styles/CommonStyles.js
@@ -1,9 +1,10 @@
-import styled, { keyframes } from 'styled-components';
-
+import styled from 'styled-components';
 // assets
 import CreditImage from '@assets/svg/ic_credit.svg';
 import CreditWhiteImage from '@assets/svg/ic_credit_white.svg';
 import DeleteButton from '@assets/svg/btn_delete_24px.svg';
+import ArrowLeftButton from '@assets/svg/ic_arrow_left.svg';
+import LeftTopGradient from '@assets/svg/Image_top.svg';
 
 export const StyledDeleteButton = styled.button`
   width: 24px;
@@ -11,6 +12,16 @@ export const StyledDeleteButton = styled.button`
   cursor: pointer;
 
   background-image: url(${DeleteButton});
+  background-repeat: no-repeat;
+  background-position: center;
+`;
+
+export const StyledArrowLeftButton = styled.button`
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+
+  background-image: url(${ArrowLeftButton});
   background-repeat: no-repeat;
   background-position: center;
 `;
@@ -30,6 +41,21 @@ const BasedCreditIcon = styled.i`
   background-repeat: no-repeat;
   background-size: 100%;
   background-position: center;
+`;
+
+export const LeftTopGradientDesign = styled.div`
+  display: block;
+  position: absolute;
+  width: 199px;
+  height: 273px;
+  top: 0;
+  left: 0;
+  z-index: 1;
+
+  background-image: url(${LeftTopGradient});
+  background-repeat: no-repeat;
+  background-size: 100%;
+  background-position: top;
 `;
 
 export const StyledCreditIcon = styled(BasedCreditIcon)`


### PR DESCRIPTION
## @ #47

### 변경사항
- `VoteModal` 모바일 전용 UI 구현
  - 반응형에 따라 불러오는 데이터 갯수 다르게 구현
- 모든 모달에서 상호작용이 일어날 시 간단한 알림 팝업 띄우기
  - `DonationModal` 후원을 완료했습니다.
  - `VoteModal` 투표를 완료했습니다.
  - `ChargeModal` ~만큼의 크레딧 충전을 완료했습니다.
- 모든 모달에서 외부 영역(백그라운드)를 클릭 시 모달 팝업 닫기

### 셀프 체크 리스트

- [x] 코드 컨벤션 준수
- [x] 테스트 여부

### 스크린샷

![image](https://github.com/user-attachments/assets/37ff4df2-c422-4621-84cd-3fbaaa876531)
![image](https://github.com/user-attachments/assets/943af591-405b-451e-9d78-336698df6632)

### 추가 공유 사항
- Toast 를 추가해보았어요...