### PR TITLE
feat(염정훈): 리스트 페이지(후원을 기다리는 조공, 이달의 차트) 기능 구현(#54)

### DIFF
--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -11,8 +11,8 @@ const MaskedBackground = styled.div`
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: inherit;
-  height: inherit;
+  width: ${(props) => (props.width === '100%' ? props.width : 'inherit')};
+  height: ${(props) => (props.height === '100%' ? props.height : 'inherit')};
   z-index: 9998;
 `;
 
@@ -21,8 +21,8 @@ const SpinnerOverlay = styled.div`
   top: 0;
   left: 0;
   background-color: var(--light-black);
-  width: inherit;
-  height: inherit;
+  width: ${(props) => (props.width === '100%' ? props.width : 'inherit')};
+  height: ${(props) => (props.height === '100%' ? props.height : 'inherit')};
   display: flex;
   justify-content: center;
   align-items: center;
@@ -36,6 +36,8 @@ export default function LoadingSpinner({
   size = 20,
   color = 'var(--brand-coral)',
   minLoadTime = 1500,
+  width,
+  height,
 }) {
   const [isVisible, setIsVisible] = useState(true);
 
@@ -48,8 +50,8 @@ export default function LoadingSpinner({
   }, [minLoadTime]);
 
   return isVisible ? (
-    <MaskedBackground>
-      <SpinnerOverlay>
+    <MaskedBackground width={width} height={height}>
+      <SpinnerOverlay width={width} height={height}>
         <PulseLoader size={size} color={color} />
       </SpinnerOverlay>
     </MaskedBackground>
@@ -60,4 +62,6 @@ LoadingSpinner.propTypes = {
   size: PropTypes.number.isRequired,
   color: PropTypes.string.isRequired,
   minLoadTime: PropTypes.number.isRequired,
+  width: PropTypes.string,
+  height: PropTypes.string,
 };

--- a/src/pages/ListPage/ListPage.jsx
+++ b/src/pages/ListPage/ListPage.jsx
@@ -1,5 +1,6 @@
 import { ModalProvider, useModalContext } from '@contexts/useModalContext';
 import { CreditProvider } from '@contexts/useCreditContext';
+import styled from 'styled-components';
 // Modals
 import ChargeModal from '@components/Modal/ChargeModal';
 import PopupModal from '@components/Modal/PopupModal';
@@ -7,6 +8,7 @@ import DonationModal from '@components/Modal/DonationModal';
 import VoteModal from '@components/Modal/VoteModal';
 // Components
 import Header from '@components/Header';
+import LeftTopGradient from '@assets/svg/Image_top.svg';
 import MyCredit from './components/MyCredit';
 import TributeSupport from './components/TributeSupport';
 import MonthChart from './components/MonthChart';
@@ -42,6 +44,7 @@ function ListPageContent() {
         />
       )}
       <Header />
+      <LeftTopGradientDesign />
       <MyCredit openModal={openModal} />
       <TributeSupport />
       <MonthChart openModal={openModal} />
@@ -58,3 +61,17 @@ export default function ListPage() {
     </CreditProvider>
   );
 }
+
+export const LeftTopGradientDesign = styled.div`
+  display: block;
+  position: absolute;
+  width: 199px;
+  height: 273px;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  background-image: url(${LeftTopGradient});
+  background-repeat: no-repeat;
+  background-size: cover;
+  background-position: top;
+`;

--- a/src/pages/ListPage/components/IdolCard.jsx
+++ b/src/pages/ListPage/components/IdolCard.jsx
@@ -1,5 +1,5 @@
 import { PropTypes } from 'prop-types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useModalContext } from '@contexts/useModalContext';
 import styled from 'styled-components';
 import Button from '@components/Button';
@@ -29,7 +29,9 @@ export default function IdolCard({ donation }) {
     setDonationValue: () => {
       setDonationValue();
     },
+    donationTarget: donation ? donation.targetDonation : null,
   });
+  const [donationPercentage, setDonationPercentage] = useState(0);
 
   // Context
   const { openModal } = useModalContext();
@@ -37,6 +39,17 @@ export default function IdolCard({ donation }) {
   const handleTributeButtonClick = () => {
     openModal('DonationModal', idolStatus);
   };
+
+  // 목표 도네이션까지 달성된 도네이션 퍼센테이지 값 구하기
+  useEffect(() => {
+    const calculatePercentage = () => {
+      const result =
+        (idolStatus.donationReceivedDonation / idolStatus.donationTarget) * 100;
+      return setDonationPercentage(result);
+    };
+
+    calculatePercentage();
+  }, [donation]);
 
   return (
     <IdolCardWrap>
@@ -57,7 +70,7 @@ export default function IdolCard({ donation }) {
             </div>
             <span>{idolStatus?.donationDeadLineDay ?? '??'}일 남음</span>
           </IdolCardCredit>
-          <IdolCardCreditGauge />
+          <IdolCardCreditGauge donationPercentage={donationPercentage} />
         </div>
       </IdolCardText>
     </IdolCardWrap>
@@ -75,6 +88,7 @@ IdolCard.propTypes = {
       profilePicture: PropTypes.string.isRequired,
     }).isRequired,
     receivedDonations: PropTypes.number.isRequired,
+    targetDonation: PropTypes.number.isRequired,
   }).isRequired,
 };
 
@@ -214,9 +228,11 @@ const IdolCardCreditGauge = styled.div`
     position: absolute;
     top: 0;
     left: 0;
-    width: 25%;
+    width: ${(props) =>
+      props.donationPercentage ? props.donationPercentage : 0}%;
     height: 100%;
     content: '';
     background-color: var(--brand-coral);
+    transition: all 0.3s;
   }
 `;

--- a/src/pages/ListPage/components/IdolCard.jsx
+++ b/src/pages/ListPage/components/IdolCard.jsx
@@ -58,8 +58,12 @@ export default function IdolCard({ donation }) {
         <Button onClick={handleTributeButtonClick}>후원하기</Button>
       </IdolCardImage>
       <IdolCardText>
-        <span>{idolStatus?.donationSubtitle ?? '임시 서브 타이틀'}</span>
-        <p>{idolStatus?.donationTitle ?? '임시 메인 타이틀'}</p>
+        <span title={idolStatus.donationSubtitle}>
+          {idolStatus?.donationSubtitle ?? '임시 서브 타이틀'}
+        </span>
+        <p title={idolStatus.donationTitle}>
+          {idolStatus?.donationTitle ?? '임시 메인 타이틀'}
+        </p>
         <div>
           <IdolCardCredit>
             <div>
@@ -172,6 +176,13 @@ const Image = styled.div`
 `;
 
 const IdolCardText = styled.div`
+  & > span,
+  & > p {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
   & > span {
     display: inline-block;
     font-size: 1.6rem;

--- a/src/pages/ListPage/components/MonthChart.jsx
+++ b/src/pages/ListPage/components/MonthChart.jsx
@@ -13,20 +13,50 @@ export default function MonthChart({ openModal }) {
   const FEMALE = 'female';
   const MALE = 'male';
   const PAGE_SIZE = 10;
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
   const [genderTab, setGenderTab] = useState(FEMALE);
-  const [chartPageSize, setChartPageSize] = useState(PAGE_SIZE);
+  const [chartPageSize, setChartPageSize] = useState(
+    windowWidth >= 744 ? PAGE_SIZE : 5
+  );
   const [nextCursorValue, setNextCursorValue] = useState();
   const [moreButtonDisabled, setMoreButtonDisabled] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
+  // 더보기 버튼 클릭
   const handleClickMoreButton = () => {
-    setChartPageSize(chartPageSize + 10);
+    if (windowWidth <= 744) {
+      setChartPageSize(chartPageSize + 5);
+    } else {
+      setChartPageSize(chartPageSize + 10);
+    }
   };
 
+  // 접기 버튼 클릭
   const handleClickShortButton = () => {
-    setChartPageSize(10);
+    if (windowWidth <= 744) {
+      setChartPageSize(5);
+    } else {
+      setChartPageSize(10);
+    }
   };
 
+  // 브라우저 사이즈 변경되면 현재 사이즈 반환
+  useEffect(() => {
+    const handleResize = () => setWindowWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [windowWidth]);
+
+  // 반응형으로 차트 노출 개수 정하기
+  useEffect(() => {
+    if (windowWidth <= 744) {
+      setChartPageSize(5);
+    } else if (windowWidth > 744) {
+      setChartPageSize(10);
+    }
+  }, [windowWidth]);
+
+  // nextCursor값 가져오기
   useEffect(() => {
     const handleLoad = async () => {
       try {
@@ -47,6 +77,7 @@ export default function MonthChart({ openModal }) {
     handleLoad();
   }, [chartPageSize]);
 
+  // nextCursor값이 null로 더는 불러올 아이돌 데이터가 없으면 더보기 버튼 숨기고 접기 버튼 노출
   useEffect(() => {
     if (nextCursorValue === null) {
       setMoreButtonDisabled(true);
@@ -78,6 +109,7 @@ export default function MonthChart({ openModal }) {
         genderTab={genderTab}
         setGenderTab={setGenderTab}
         setChartPageSize={setChartPageSize}
+        windowWidth={windowWidth}
       />
       <MonthChartList
         idolGender={genderTab === 'female' ? FEMALE : MALE}

--- a/src/pages/ListPage/components/MonthChart.jsx
+++ b/src/pages/ListPage/components/MonthChart.jsx
@@ -61,6 +61,8 @@ export default function MonthChart({ openModal }) {
         isLoading={isLoading}
         color="var(--brand-coral)"
         size={20}
+        width="100%"
+        height="100%"
         minLoadTime={1000}
       />
       <div>

--- a/src/pages/ListPage/components/MonthChartList.jsx
+++ b/src/pages/ListPage/components/MonthChartList.jsx
@@ -3,24 +3,19 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 // api
 import { getCharts } from '@apis/idolApi';
-import LoadingSpinner from '@components/LoadingSpinner';
 // component
 import MonthIdol from './MonthIdol';
 
 export default function MonthChartList({ idolGender, chartPageSize }) {
   const [chartIdolsData, setChartIdolsData] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const handleLoad = async (option) => {
       try {
         const { idols } = await getCharts(option);
         setChartIdolsData(idols);
-        setIsLoading(false);
       } catch (error) {
         console.error(error);
-      } finally {
-        setIsLoading(false);
       }
     };
 
@@ -29,12 +24,6 @@ export default function MonthChartList({ idolGender, chartPageSize }) {
 
   return (
     <MonthIdolList>
-      <LoadingSpinner
-        isLoading={isLoading}
-        color="var(--brand-coral)"
-        size={20}
-        minLoadTime={1000}
-      />
       {chartIdolsData.map((idolsData) => {
         return <MonthIdol key={idolsData.id} idolsData={idolsData} />;
       })}

--- a/src/pages/ListPage/components/MonthChartTab.jsx
+++ b/src/pages/ListPage/components/MonthChartTab.jsx
@@ -5,17 +5,27 @@ export default function MonthChartTab({
   genderTab,
   setGenderTab,
   setChartPageSize,
+  windowWidth,
 }) {
   const FEMALE = 'female';
   const MALE = 'male';
 
+  const resizeWindow = () => {
+    if (windowWidth <= 744) {
+      setChartPageSize(5);
+    } else {
+      setChartPageSize(10);
+    }
+  };
+
   const handleClickTab = (gender) => {
     if (gender === FEMALE) {
       setGenderTab(FEMALE);
-      setChartPageSize(10);
+      resizeWindow();
     } else if (gender === MALE) {
       setGenderTab(MALE);
       setChartPageSize(10);
+      resizeWindow();
     }
   };
 
@@ -47,6 +57,7 @@ MonthChartTab.propTypes = {
   genderTab: PropTypes.string.isRequired,
   setGenderTab: PropTypes.func.isRequired,
   setChartPageSize: PropTypes.func.isRequired,
+  windowWidth: PropTypes.number.isRequired,
 };
 
 const ChartTab = styled.div`

--- a/src/pages/ListPage/components/TributeSupport.jsx
+++ b/src/pages/ListPage/components/TributeSupport.jsx
@@ -40,7 +40,7 @@ export default function TributeSupport() {
 
   // swiper 자동 재생
   const SWIPER_AUTOPLAY = {
-    delay: 4000, // 4초마다 자동 재생
+    delay: 6000, // 6초마다 자동 재생
     disableOnInteraction: false, // 사용자가 슬라이더를 변경해도 자동재생 유지
   };
 


### PR DESCRIPTION
### 변경사항

-  후원을 위한 조공 게이지 구현
-  후원을 위한 조공 텍스트 줄바꿈 될 때 height 오류 수정(한줄씩만 노출되고 그 이후로는 말줄임 표시)
-  이달의 차트 모바일 버전 5개만 보이도록 구현
-  이달의 차트 모바일 버전은 더보기 클릭시 5개씩만 노출되도록 구현
-  로딩 스피너 width, height 속성 추가
-  탑 왼쪽 상단 배경 이미지 넣기

### 셀프 체크 리스트

- [x] 코드 컨벤션 준수
- [x] 테스트 여부

### 스크린샷
- 게이지 구현
![image](https://github.com/user-attachments/assets/26502232-f6b2-47c3-8f26-32334fade44c)

- 텍스트 말줄임 추가
![image](https://github.com/user-attachments/assets/f24e83a7-19a1-4bb7-a77e-d9da9f46033e)

- 이달의 차트 모바일 버전 5개만 보이도록 구현
![image](https://github.com/user-attachments/assets/2e35caca-d77f-49c5-939d-d35ca0038274)

- 이달의 차트 모바일 버전은 더보기 클릭시 5개씩만 노출되도록 구현
![image](https://github.com/user-attachments/assets/109e674f-b530-419d-970b-2fef7f47d0ca)

- 탑 왼쪽 상단 배경 이미지 넣기
![image](https://github.com/user-attachments/assets/03a2b1b5-8ed0-44e8-bded-0159466512c0)

